### PR TITLE
Add ability to set/override values of job parameters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scripttrigger/groovy/GroovyScriptTriggerExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/scripttrigger/groovy/GroovyScriptTriggerExecutor.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * @author Gregory Boissinot
@@ -48,7 +49,7 @@ public class GroovyScriptTriggerExecutor extends ScriptTriggerExecutor {
         super(log);
     }
 
-    public boolean evaluateGroovyScript(Node executingNode, final AbstractProject proj, final String scriptContent, final Map<String, String> envVars, boolean groovySystemScript) throws ScriptTriggerException {
+    public boolean evaluateGroovyScript(Node executingNode, final AbstractProject proj, final String scriptContent, final Map<String, String> envVars, final Properties parameters, boolean groovySystemScript) throws ScriptTriggerException {
 
         if (scriptContent == null) {
             throw new NullPointerException("The script content object must be set.");
@@ -56,13 +57,13 @@ public class GroovyScriptTriggerExecutor extends ScriptTriggerExecutor {
         try {
             if (groovySystemScript) {
                 log.info("Running as system script");
-                return evaluateGroovyScript(proj, scriptContent, envVars);
+                return evaluateGroovyScript(proj, scriptContent, envVars, parameters);
             }
 
             return executingNode.getRootPath().act(new Callable<Boolean, ScriptTriggerException>() {
                 public Boolean call() throws ScriptTriggerException {
                     log.info("Running as node script");
-                    return evaluateGroovyScript(null, scriptContent, envVars);
+                    return evaluateGroovyScript(null, scriptContent, envVars, parameters);
                 }
             });
         } catch (IOException ioe) {
@@ -80,7 +81,7 @@ public class GroovyScriptTriggerExecutor extends ScriptTriggerExecutor {
         }
     }
 
-    private boolean evaluateGroovyScript(final AbstractProject proj, final String scriptContent, final Map<String, String> envVars) {
+    private boolean evaluateGroovyScript(final AbstractProject proj, final String scriptContent, final Map<String, String> envVars, final Properties parameters) {
         if (envVars != null) {
             final StringBuilder envDebug = new StringBuilder("Replacing script vars using:");
             for (final Map.Entry<String, String> envEntry : envVars.entrySet()) {
@@ -108,6 +109,7 @@ public class GroovyScriptTriggerExecutor extends ScriptTriggerExecutor {
 
         shell.setVariable("log", log);
         shell.setVariable("out", log.getListener().getLogger());
+        shell.setVariable("parameters", parameters);
         if (proj != null) {
             shell.setVariable("project", proj);
         }
@@ -148,7 +150,7 @@ public class GroovyScriptTriggerExecutor extends ScriptTriggerExecutor {
         return cl;
     }
 
-    public boolean evaluateGroovyScriptFilePath(Node executingNode, AbstractProject proj, String scriptFilePath, Map<String, String> envVars, boolean groovySystemScript) throws ScriptTriggerException {
+    public boolean evaluateGroovyScriptFilePath(Node executingNode, AbstractProject proj, String scriptFilePath, Map<String, String> envVars, final Properties parameters, boolean groovySystemScript) throws ScriptTriggerException {
 
         if (scriptFilePath == null) {
             throw new NullPointerException("The scriptFilePath object must be set.");
@@ -189,7 +191,7 @@ public class GroovyScriptTriggerExecutor extends ScriptTriggerExecutor {
             scriptContent = getStringContent(executingNode, scriptFilePath);
         }
 
-        return evaluateGroovyScript(executingNode, proj, scriptContent, envVars, groovySystemScript);
+        return evaluateGroovyScript(executingNode, proj, scriptContent, envVars, parameters, groovySystemScript);
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/scripttrigger/groovy/ParameterParser.java
+++ b/src/main/java/org/jenkinsci/plugins/scripttrigger/groovy/ParameterParser.java
@@ -1,0 +1,48 @@
+package org.jenkinsci.plugins.scripttrigger.groovy;
+
+import antlr.ANTLRException;
+import hudson.scheduler.CronTabList;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Calendar;
+import java.util.Properties;
+
+public class ParameterParser {
+
+    private static final String PARAMETER_ANNOTATION = "@param";
+
+    public Properties findParameters(String cronTabSpec, Calendar calendar) throws ANTLRException {
+        Properties parameters = new Properties();
+        for (String line : cronTabSpec.split(System.lineSeparator())) {
+            if (line.length() == 0) {
+                continue;
+            }
+            if (line.startsWith("#")) {
+                if (line.substring(1).startsWith(PARAMETER_ANNOTATION)) {
+                    parameters.putAll(parseParameters(line.substring(1 + PARAMETER_ANNOTATION.length())));
+                }
+            } else {
+                if (CronTabList.create(line).check(calendar)) {
+                    break;
+                }
+                parameters.clear();
+            }
+        }
+        return parameters;
+    }
+
+    private Properties parseParameters(String parameterStr) {
+        Properties parameters = new Properties();
+        if (StringUtils.isBlank(parameterStr)) {
+            return parameters;
+        }
+        parameterStr = parameterStr.trim();
+        int separatorInd = parameterStr.indexOf(' ');
+        if (separatorInd < 0) {
+            parameters.setProperty(parameterStr, "");
+        } else {
+            parameters.setProperty(parameterStr.substring(0, separatorInd), parameterStr.substring(separatorInd).trim());
+        }
+        return parameters;
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/scripttrigger/groovy/GroovyScriptTrigger/help-groovyExpression.html
+++ b/src/main/resources/org/jenkinsci/plugins/scripttrigger/groovy/GroovyScriptTrigger/help-groovyExpression.html
@@ -9,4 +9,19 @@
             f.exists()
         </i>
     </p>
+    <p>
+        Scheduler field supports parameters in format:<br/>
+        <code>#@param &lt;name&gt; [value]</code><br/>
+        <br/>
+        Parameters are applied to a cron item above which they are listed.<br/>
+        These parameters values override ones of default job parameters.<br/>
+        No quotes are needed in case a parameter value contains whitespaces.<br/>
+        A parameter value may be omitted. In this case it will be assumed as an empty one.
+    </p>
+    <p>
+        Predefined variables:
+    </p>
+    <dl>
+        <dt><code>parameters</code></dt><dd>Parameters defined in Scheduler.</dd>
+    </dl>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/scripttrigger/groovy/GroovyScriptTrigger/help-groovyFilePath.html
+++ b/src/main/resources/org/jenkinsci/plugins/scripttrigger/groovy/GroovyScriptTrigger/help-groovyFilePath.html
@@ -2,4 +2,19 @@
     <p>
         Give a groovy script path.
     </p>
+    <p>
+        Scheduler field supports parameters in format:<br/>
+        <code>#@param &lt;name&gt; [value]</code><br/>
+        <br/>
+        Parameters are applied to a cron item above which they are listed.<br/>
+        These parameters values override ones of default job parameters.<br/>
+        No quotes are needed in case a parameter value contains whitespaces.<br/>
+        A parameter value may be omitted. In this case it will be assumed as an empty one.
+    </p>
+    <p>
+        Predefined variables:
+    </p>
+    <dl>
+        <dt><code>parameters</code></dt><dd>Parameters defined in Scheduler.</dd>
+    </dl>
 </div>


### PR DESCRIPTION
Could be used in Scheduler field as a commented line. In this field comments follow a sharp sign (#).
So start each param line with the sign.

Syntax:
  @param <name> [value]

Parameters are applied to a cron item above which they are listed. These parameters values override ones of default job parameters. No quotes are needed in case a parameter value contains whitespaces. A parameter value may be omitted. In this case it will be assumed as an empty one.